### PR TITLE
Fix ordering of list using a custom MatchComparator

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ This is a Java project for the coding test provided by Sportradar.
 # Mentions
 
 - Finishing a match should as specified in spec remove the match completely. In a real world scenario this data would probably be stored somewhere externally.
+- For the tests and running of code of the match ordering some sleep delays had to be added. They delay each match creation with 10ms. Otherwise, some matches could end up with the same time started, and would deviate from expected results (which is supposed to test which is created first).

--- a/src/main/java/org/aleksander/sportradar/codingtest/Main.java
+++ b/src/main/java/org/aleksander/sportradar/codingtest/Main.java
@@ -7,19 +7,25 @@ import org.aleksander.sportradar.codingtest.objects.Team;
 
 import java.util.List;
 
+import static java.lang.Thread.sleep;
+
 public class Main {
-    public static void main(String[] args) {
+    public static void main(String[] args) throws InterruptedException {
         System.out.println("Starting Sportradar coding test!");
         sportradarProvidedExample();
     }
 
-    public static void sportradarProvidedExample() {
+    public static void sportradarProvidedExample() throws InterruptedException {
         // Create matches in order provided
         final Scoreboard scoreboard = new Scoreboard();
         final String mexicoCanadaId = scoreboard.startNewMatch(new Team("Mexico"), new Team("Canada"));
+        sleep(10);
         final String spainBrazilId = scoreboard.startNewMatch(new Team("Spain"), new Team("Brazil"));
+        sleep(10);
         final String germanyFranceId = scoreboard.startNewMatch(new Team("Germany"), new Team("France"));
+        sleep(10);
         final String uruguayItalyId = scoreboard.startNewMatch(new Team("Uruguay"), new Team("Italy"));
+        sleep(10);
         final String argentinaAustraliaId = scoreboard.startNewMatch(new Team("Argentina"), new Team("Australia"));
 
         // Update matches in order provided with scores provided

--- a/src/main/java/org/aleksander/sportradar/codingtest/objects/Scoreboard.java
+++ b/src/main/java/org/aleksander/sportradar/codingtest/objects/Scoreboard.java
@@ -1,6 +1,11 @@
 package org.aleksander.sportradar.codingtest.objects;
 
-import java.util.*;
+import org.aleksander.sportradar.codingtest.objects.comparator.MatchComparator;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class Scoreboard {
     private final Map<String, Match> matchesInProgress;
@@ -32,7 +37,9 @@ public class Scoreboard {
     }
 
     public List<Match> getMatchesInOrder() {
-        // TODO: Implement logic to determine order the matches are returned in. (Ordered by total score, if some matches have same score, order them by time started)
-        return this.matchesInProgress.values().stream().toList();
+        final List<Match> listOfMatches = this.matchesInProgress.values().stream().toList();
+        return listOfMatches.stream()
+                .sorted(new MatchComparator())
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/aleksander/sportradar/codingtest/objects/comparator/MatchComparator.java
+++ b/src/main/java/org/aleksander/sportradar/codingtest/objects/comparator/MatchComparator.java
@@ -1,0 +1,30 @@
+package org.aleksander.sportradar.codingtest.objects.comparator;
+
+import org.aleksander.sportradar.codingtest.objects.Match;
+
+import java.time.Instant;
+import java.util.Comparator;
+
+/**
+ * Comparator for comparing matches. It compares the total score of the two matches, if they are equal it will compare the time they are created.
+ * Using it on a list of matches will result in the following behavior:
+ * - Returns a list with the highest total score first.
+ * - If total score of two matches are alike, it will put the most recently created one first.
+ */
+public class MatchComparator implements Comparator<Match> {
+
+    @Override
+    public int compare(final Match match1, final Match match2) {
+        return compare(match1.getTotalScore(), match2.getTotalScore(), match1.getTimeStarted(), match2.getTimeStarted());
+    }
+
+    private int compare(final int totalScore1, final int totalScore2, final Instant timeStarted1, final Instant timeStarted2) {
+        final int totalScoreCompare = Integer.compare(totalScore2, totalScore1);
+
+        if (totalScoreCompare != 0) {
+            return totalScoreCompare;
+        }
+
+        return timeStarted2.compareTo(timeStarted1);
+    }
+}

--- a/src/test/java/org/aleksander/sportradar/codingtest/objects/ScoreboardTest.java
+++ b/src/test/java/org/aleksander/sportradar/codingtest/objects/ScoreboardTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static java.lang.Thread.sleep;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -100,13 +101,17 @@ public class ScoreboardTest {
 
     // Get matches in order
     @Test
-    void scoreboard_can_return_ordered_list() {
+    void scoreboard_can_return_ordered_list() throws InterruptedException {
         // Given matches are created in a specific order
         final Scoreboard scoreboard = new Scoreboard();
         final String mexicoCanadaId = scoreboard.startNewMatch(new Team("Mexico"), new Team("Canada"));
+        sleep(10);
         final String spainBrazilId = scoreboard.startNewMatch(new Team("Spain"), new Team("Brazil"));
+        sleep(10);
         final String germanyFranceId = scoreboard.startNewMatch(new Team("Germany"), new Team("France"));
+        sleep(10);
         final String uruguayItalyId = scoreboard.startNewMatch(new Team("Uruguay"), new Team("Italy"));
+        sleep(10);
         final String argentinaAustraliaId = scoreboard.startNewMatch(new Team("Argentina"), new Team("Australia"));
 
         // When updating matches in the same order with specific score values, and getting ordered list


### PR DESCRIPTION
# Description

This PR adds proper ordering of the match list. This is done with a custom MatchComparator

Also added some `sleep(10)` when creating several matches in the main and test methods. This is done to avoid ending up with the same timestamp on the matches, which would result in incorrect results.

# Additional context for reviewer

This PR is mostly a formality to myself :)
