### PR TITLE
Improve error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ This is a Java project for the coding test provided by Sportradar.
 
 - Finishing a match should as specified in spec remove the match completely. In a real world scenario this data would probably be stored somewhere externally.
 - For the tests and running of code of the match ordering some sleep delays had to be added. They delay each match creation with 10ms. Otherwise, some matches could end up with the same time started, and would deviate from expected results (which is supposed to test which is created first).
+- For the error handling in the Match.setMatchScore, I decided that a null isn't a valid input, but shouldn't crash the entire system. Therefore it simply ignores the set call.

--- a/src/main/java/org/aleksander/sportradar/codingtest/Main.java
+++ b/src/main/java/org/aleksander/sportradar/codingtest/Main.java
@@ -1,5 +1,6 @@
 package org.aleksander.sportradar.codingtest;
 
+import org.aleksander.sportradar.codingtest.exceptions.EntryNotFoundException;
 import org.aleksander.sportradar.codingtest.objects.Match;
 import org.aleksander.sportradar.codingtest.objects.Score;
 import org.aleksander.sportradar.codingtest.objects.Scoreboard;
@@ -10,12 +11,12 @@ import java.util.List;
 import static java.lang.Thread.sleep;
 
 public class Main {
-    public static void main(String[] args) throws InterruptedException {
+    public static void main(String[] args) throws InterruptedException, EntryNotFoundException {
         System.out.println("Starting Sportradar coding test!");
         sportradarProvidedExample();
     }
 
-    public static void sportradarProvidedExample() throws InterruptedException {
+    public static void sportradarProvidedExample() throws InterruptedException, EntryNotFoundException {
         // Create matches in order provided
         final Scoreboard scoreboard = new Scoreboard();
         final String mexicoCanadaId = scoreboard.startNewMatch(new Team("Mexico"), new Team("Canada"));

--- a/src/main/java/org/aleksander/sportradar/codingtest/exceptions/EntryNotFoundException.java
+++ b/src/main/java/org/aleksander/sportradar/codingtest/exceptions/EntryNotFoundException.java
@@ -4,8 +4,4 @@ public class EntryNotFoundException extends Exception {
     public EntryNotFoundException(final String message) {
         super(message);
     }
-
-    public EntryNotFoundException(final String message, final Exception cause) {
-        super(message, cause);
-    }
 }

--- a/src/main/java/org/aleksander/sportradar/codingtest/exceptions/EntryNotFoundException.java
+++ b/src/main/java/org/aleksander/sportradar/codingtest/exceptions/EntryNotFoundException.java
@@ -1,0 +1,11 @@
+package org.aleksander.sportradar.codingtest.exceptions;
+
+public class EntryNotFoundException extends Exception {
+    public EntryNotFoundException(final String message) {
+        super(message);
+    }
+
+    public EntryNotFoundException(final String message, final Exception cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/aleksander/sportradar/codingtest/exceptions/InvalidArgumentException.java
+++ b/src/main/java/org/aleksander/sportradar/codingtest/exceptions/InvalidArgumentException.java
@@ -1,0 +1,7 @@
+package org.aleksander.sportradar.codingtest.exceptions;
+
+public class InvalidArgumentException extends RuntimeException {
+    public InvalidArgumentException(final String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/aleksander/sportradar/codingtest/objects/Match.java
+++ b/src/main/java/org/aleksander/sportradar/codingtest/objects/Match.java
@@ -1,6 +1,8 @@
 package org.aleksander.sportradar.codingtest.objects;
 
+import java.security.InvalidParameterException;
 import java.time.Instant;
+import java.util.Objects;
 import java.util.UUID;
 
 public class Match {
@@ -13,8 +15,8 @@ public class Match {
 
     public Match(final Team homeTeam, final Team awayTeam) {
         this.matchId = createMatchId();
-        this.homeTeam = homeTeam;
-        this.awayTeam = awayTeam;
+        this.homeTeam = requireNonNullOrEmpty(homeTeam);
+        this.awayTeam = requireNonNullOrEmpty(awayTeam);
         // A match always starts at 0 - 0.
         this.matchScore = new Score(0, 0);
         // Set time of creation
@@ -52,10 +54,24 @@ public class Match {
     }
 
     public void setMatchScore(final Score matchScore) {
-        this.matchScore = matchScore;
+        // This method could in theory be expanded upon to include that none of the scores could have decreased. But this is not specified in the spec, so will not do.
+        if (matchScore != null) {
+            this.matchScore = matchScore;
+        }
+        else {
+            // If input is 'null' it will log the event and NOT set the score
+            System.out.println("Invalid score was input. Ignoring the input.");
+        }
     }
 
     public Instant getTimeStarted() {
         return timeStarted;
+    }
+
+    private Team requireNonNullOrEmpty(final Team team) {
+        if (team == null || team.teamName() == null || team.teamName().isEmpty()) {
+            throw new InvalidParameterException("A team cannot be 'null' or contain 'null' or empty team name");
+        }
+        return team;
     }
 }

--- a/src/main/java/org/aleksander/sportradar/codingtest/objects/Match.java
+++ b/src/main/java/org/aleksander/sportradar/codingtest/objects/Match.java
@@ -1,8 +1,8 @@
 package org.aleksander.sportradar.codingtest.objects;
 
-import java.security.InvalidParameterException;
+import org.aleksander.sportradar.codingtest.exceptions.InvalidArgumentException;
+
 import java.time.Instant;
-import java.util.Objects;
 import java.util.UUID;
 
 public class Match {
@@ -69,8 +69,9 @@ public class Match {
     }
 
     private Team requireNonNullOrEmpty(final Team team) {
-        if (team == null || team.teamName() == null || team.teamName().isEmpty()) {
-            throw new InvalidParameterException("A team cannot be 'null' or contain 'null' or empty team name");
+        // teamName being null is covered by Team class
+        if (team == null) {
+            throw new InvalidArgumentException("A team cannot be 'null'");
         }
         return team;
     }

--- a/src/main/java/org/aleksander/sportradar/codingtest/objects/Scoreboard.java
+++ b/src/main/java/org/aleksander/sportradar/codingtest/objects/Scoreboard.java
@@ -28,7 +28,7 @@ public class Scoreboard {
     }
 
     public void updateScoreOfMatch(final String matchId, final Score newScore) {
-        final Match matchToUpdate = this.matchesInProgress.get(matchId);
+        final Match matchToUpdate = getMatch(matchId);
         matchToUpdate.setMatchScore(newScore);
     }
 

--- a/src/main/java/org/aleksander/sportradar/codingtest/objects/Scoreboard.java
+++ b/src/main/java/org/aleksander/sportradar/codingtest/objects/Scoreboard.java
@@ -1,5 +1,7 @@
 package org.aleksander.sportradar.codingtest.objects;
 
+import org.aleksander.sportradar.codingtest.exceptions.EntryNotFoundException;
+import org.aleksander.sportradar.codingtest.exceptions.InvalidArgumentException;
 import org.aleksander.sportradar.codingtest.objects.comparator.MatchComparator;
 
 import java.util.HashMap;
@@ -22,17 +24,29 @@ public class Scoreboard {
         return matchId;
     }
 
-    // TODO: determine if this method should throw a NotFoundException if no match is found with that matchId
-    public Match getMatch(final String matchId) {
-        return matchesInProgress.get(matchId);
+    public Match getMatch(final String matchId) throws EntryNotFoundException {
+        if (matchId == null || matchId.isEmpty()) {
+            throw new InvalidArgumentException("Parameter 'matchId' can not be 'null' or empty.");
+        }
+        final Match retrievedMatch = matchesInProgress.get(matchId);
+        if (retrievedMatch == null) {
+            throw new EntryNotFoundException("No match entry was found when trying to get match with matchId '" + matchId + "'");
+        }
+        return retrievedMatch;
     }
 
-    public void updateScoreOfMatch(final String matchId, final Score newScore) {
+    public void updateScoreOfMatch(final String matchId, final Score newScore) throws EntryNotFoundException {
+        if (newScore == null) {
+            throw new InvalidArgumentException("The score provided can not be 'null'");
+        }
         final Match matchToUpdate = getMatch(matchId);
         matchToUpdate.setMatchScore(newScore);
     }
 
-    public void finishMatch(final String matchId) {
+    public void finishMatch(final String matchId) throws EntryNotFoundException {
+        // Get the match to see if matchId is valid and if match exists.
+        getMatch(matchId);
+        // If no exceptions are thrown during getting of match, then we can remove it.
         matchesInProgress.remove(matchId);
     }
 

--- a/src/main/java/org/aleksander/sportradar/codingtest/objects/Team.java
+++ b/src/main/java/org/aleksander/sportradar/codingtest/objects/Team.java
@@ -1,9 +1,21 @@
 package org.aleksander.sportradar.codingtest.objects;
 
+import org.aleksander.sportradar.codingtest.exceptions.InvalidArgumentException;
+
 public record Team(String teamName) {
+
+    public Team {
+        requireNonNullOrEmpty(teamName);
+    }
 
     @Override
     public String toString() {
         return this.teamName;
+    }
+
+    private void requireNonNullOrEmpty(final String teamName) throws InvalidArgumentException {
+        if (teamName == null || teamName.isEmpty()) {
+            throw new InvalidArgumentException("Parameter 'teamName' cannot be null or empty!");
+        }
     }
 }

--- a/src/test/java/org/aleksander/sportradar/codingtest/objects/MatchTest.java
+++ b/src/test/java/org/aleksander/sportradar/codingtest/objects/MatchTest.java
@@ -1,13 +1,12 @@
 package org.aleksander.sportradar.codingtest.objects;
 
 
+import org.aleksander.sportradar.codingtest.exceptions.InvalidArgumentException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
 
-import java.security.InvalidParameterException;
 import java.time.Instant;
 import java.util.stream.Stream;
 
@@ -27,35 +26,19 @@ public class MatchTest {
         assertEquals("test_away_team", match.getAwayTeam().teamName());
     }
 
-    @ParameterizedTest
-    @NullAndEmptySource
-    void a_new_match_must_not_have_null_or_empty_team_names(final String invalidTeamName) {
-        // When a new match is created with invalid home team
-        final InvalidParameterException invalidParameterExceptionHome = assertThrows(
-                InvalidParameterException.class, () -> new Match(new Team(invalidTeamName), TEST_AWAY_TEAM)
-        );
-        // and a new match is created with invalid away team
-        final InvalidParameterException invalidParameterExceptionAway = assertThrows(
-                InvalidParameterException.class, () -> new Match(TEST_HOME_TEAM, new Team(invalidTeamName))
-        );
-        // Then both teams resulted in an exception with a descriptive error message
-        assertEquals("A team cannot be 'null' or contain 'null' or empty team name", invalidParameterExceptionHome.getMessage());
-        assertEquals("A team cannot be 'null' or contain 'null' or empty team name", invalidParameterExceptionAway.getMessage());
-    }
-
     @Test
     void a_new_match_must_not_have_null_team() {
         // When a new match is created with null home team
-        final InvalidParameterException invalidParameterExceptionHome = assertThrows(
-                InvalidParameterException.class, () -> new Match(null, TEST_AWAY_TEAM)
+        final InvalidArgumentException invalidArgumentExceptionHome = assertThrows(
+                InvalidArgumentException.class, () -> new Match(null, TEST_AWAY_TEAM)
         );
         // and a new match is created with null away team
-        final InvalidParameterException invalidParameterExceptionAway = assertThrows(
-                InvalidParameterException.class, () -> new Match(TEST_HOME_TEAM, null)
+        final InvalidArgumentException invalidArgumentExceptionAway = assertThrows(
+                InvalidArgumentException.class, () -> new Match(TEST_HOME_TEAM, null)
         );
         // Then both teams resulted in an exception with a descriptive error message
-        assertEquals("A team cannot be 'null' or contain 'null' or empty team name", invalidParameterExceptionHome.getMessage());
-        assertEquals("A team cannot be 'null' or contain 'null' or empty team name", invalidParameterExceptionAway.getMessage());
+        assertEquals("A team cannot be 'null'", invalidArgumentExceptionHome.getMessage());
+        assertEquals("A team cannot be 'null'", invalidArgumentExceptionAway.getMessage());
     }
 
     @Test

--- a/src/test/java/org/aleksander/sportradar/codingtest/objects/MatchTest.java
+++ b/src/test/java/org/aleksander/sportradar/codingtest/objects/MatchTest.java
@@ -39,8 +39,23 @@ public class MatchTest {
                 InvalidParameterException.class, () -> new Match(TEST_HOME_TEAM, new Team(invalidTeamName))
         );
         // Then both teams resulted in an exception with a descriptive error message
-        assertEquals("Parameter homeTeam cannot be null or empty!", invalidParameterExceptionHome.getMessage());
-        assertEquals("Parameter awayTeam cannot be null or empty!", invalidParameterExceptionAway.getMessage());
+        assertEquals("A team cannot be 'null' or contain 'null' or empty team name", invalidParameterExceptionHome.getMessage());
+        assertEquals("A team cannot be 'null' or contain 'null' or empty team name", invalidParameterExceptionAway.getMessage());
+    }
+
+    @Test
+    void a_new_match_must_not_have_null_team() {
+        // When a new match is created with null home team
+        final InvalidParameterException invalidParameterExceptionHome = assertThrows(
+                InvalidParameterException.class, () -> new Match(null, TEST_AWAY_TEAM)
+        );
+        // and a new match is created with null away team
+        final InvalidParameterException invalidParameterExceptionAway = assertThrows(
+                InvalidParameterException.class, () -> new Match(TEST_HOME_TEAM, null)
+        );
+        // Then both teams resulted in an exception with a descriptive error message
+        assertEquals("A team cannot be 'null' or contain 'null' or empty team name", invalidParameterExceptionHome.getMessage());
+        assertEquals("A team cannot be 'null' or contain 'null' or empty team name", invalidParameterExceptionAway.getMessage());
     }
 
     @Test

--- a/src/test/java/org/aleksander/sportradar/codingtest/objects/MatchTest.java
+++ b/src/test/java/org/aleksander/sportradar/codingtest/objects/MatchTest.java
@@ -5,11 +5,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 
+import java.security.InvalidParameterException;
 import java.time.Instant;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class MatchTest {
     private final static Team TEST_HOME_TEAM = new Team("test_home_team");
@@ -22,6 +25,22 @@ public class MatchTest {
         // Then the team names are created correctly
         assertEquals("test_home_team", match.getHomeTeam().teamName());
         assertEquals("test_away_team", match.getAwayTeam().teamName());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void a_new_match_must_not_have_null_or_empty_team_names(final String invalidTeamName) {
+        // When a new match is created with invalid home team
+        final InvalidParameterException invalidParameterExceptionHome = assertThrows(
+                InvalidParameterException.class, () -> new Match(new Team(invalidTeamName), TEST_AWAY_TEAM)
+        );
+        // and a new match is created with invalid away team
+        final InvalidParameterException invalidParameterExceptionAway = assertThrows(
+                InvalidParameterException.class, () -> new Match(TEST_HOME_TEAM, new Team(invalidTeamName))
+        );
+        // Then both teams resulted in an exception with a descriptive error message
+        assertEquals("Parameter homeTeam cannot be null or empty!", invalidParameterExceptionHome.getMessage());
+        assertEquals("Parameter awayTeam cannot be null or empty!", invalidParameterExceptionAway.getMessage());
     }
 
     @Test
@@ -54,6 +73,17 @@ public class MatchTest {
                 Arguments.of(0, 1, 1),
                 Arguments.of(123, 123, 246)
         );
+    }
+
+    @Test
+    void a_match_will_not_be_updated_if_score_is_null() {
+        // Given a new match
+        final Match match = new Match(TEST_HOME_TEAM, TEST_AWAY_TEAM);
+        // When the score is updated with a null object
+        match.setMatchScore(null);
+        // Then the score in the match is not updated
+        assertEquals(0, match.getMatchScore().homeScore());
+        assertEquals(0, match.getMatchScore().awayScore());
     }
 
     @Test

--- a/src/test/java/org/aleksander/sportradar/codingtest/objects/ScoreboardTest.java
+++ b/src/test/java/org/aleksander/sportradar/codingtest/objects/ScoreboardTest.java
@@ -2,14 +2,15 @@ package org.aleksander.sportradar.codingtest.objects;
 
 
 import org.aleksander.sportradar.codingtest.exceptions.EntryNotFoundException;
+import org.aleksander.sportradar.codingtest.exceptions.InvalidArgumentException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.security.InvalidParameterException;
 import java.util.List;
 
 import static java.lang.Thread.sleep;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ScoreboardTest {
     private final static Team TEST_HOME_TEAM = new Team("test_home_team");
@@ -24,7 +25,7 @@ public class ScoreboardTest {
 
     // Start new match
     @Test
-    void scoreboard_can_add_a_new_match() {
+    void scoreboard_can_add_a_new_match() throws EntryNotFoundException {
         // When a new match is started
         final String matchId = scoreboard.startNewMatch(TEST_HOME_TEAM, TEST_AWAY_TEAM);
 
@@ -51,7 +52,7 @@ public class ScoreboardTest {
     }
 
     @Test
-    void scoreboard_can_add_several_matches() {
+    void scoreboard_can_add_several_matches() throws EntryNotFoundException {
         // Given 6 different teams, when a new match is started
         final String matchId1 = scoreboard.startNewMatch(new Team("home1"), new Team("away1"));
         final String matchId2 = scoreboard.startNewMatch(new Team("home2"), new Team("away2"));
@@ -80,7 +81,7 @@ public class ScoreboardTest {
 
     // Update match
     @Test
-    void scoreboard_can_update_match() {
+    void scoreboard_can_update_match() throws EntryNotFoundException {
         // Given a new match is started
         final String matchId = scoreboard.startNewMatch(TEST_HOME_TEAM, TEST_AWAY_TEAM);
 
@@ -98,7 +99,7 @@ public class ScoreboardTest {
     }
 
     @Test
-    void scoreboard_updating_a_match_an_invalid_matchId_leads_to_an_exception() {
+    void scoreboard_updating_a_match_with_an_invalid_matchId_leads_to_an_exception() {
         // Given a new match is started
         scoreboard.startNewMatch(TEST_HOME_TEAM, TEST_AWAY_TEAM);
 
@@ -110,20 +111,20 @@ public class ScoreboardTest {
     }
 
     @Test
-    void scoreboard_updating_a_match_an_invalid_score_leads_to_an_exception() {
+    void scoreboard_updating_a_match_with_an_invalid_score_leads_to_an_exception() {
         // Given a new match is started
         final String matchId = scoreboard.startNewMatch(TEST_HOME_TEAM, TEST_AWAY_TEAM);
 
         // When using an invalid score of 'null', and trying to update a match it leads to exception
-        final InvalidParameterException invalidParameterException = assertThrows(InvalidParameterException.class, () -> scoreboard.updateScoreOfMatch(matchId, null));
+        final InvalidArgumentException invalidArgumentException = assertThrows(InvalidArgumentException.class, () -> scoreboard.updateScoreOfMatch(matchId, null));
 
         // Then a descriptive error message is given
-        assertEquals("The score provided can not be 'null'", invalidParameterException.getMessage());
+        assertEquals("The score provided can not be 'null'", invalidArgumentException.getMessage());
     }
 
     // Finish match
     @Test
-    void scoreboard_can_finish_match() {
+    void scoreboard_can_finish_match() throws EntryNotFoundException {
         // Given a new match is started and updated
         final String matchId = scoreboard.startNewMatch(TEST_HOME_TEAM, TEST_AWAY_TEAM);
         scoreboard.updateScoreOfMatch(matchId, new Score(3, 7));
@@ -131,9 +132,8 @@ public class ScoreboardTest {
         // When the match is finished by using the match ID
         scoreboard.finishMatch(matchId);
 
-        // Then the match has been removed from the map of matches
-        final Match storedMatch = scoreboard.getMatch(matchId);
-        assertNull(storedMatch);
+        // Then the match has been removed from the map of matches and throws when trying to retrieve
+        assertThrows(EntryNotFoundException.class, () -> scoreboard.getMatch(matchId));
     }
 
     @Test
@@ -150,7 +150,7 @@ public class ScoreboardTest {
 
     // Get matches in order
     @Test
-    void scoreboard_can_return_ordered_list() throws InterruptedException {
+    void scoreboard_can_return_ordered_list() throws InterruptedException, EntryNotFoundException {
         // Given matches are created in a specific order
         final Scoreboard scoreboard = new Scoreboard();
         final String mexicoCanadaId = scoreboard.startNewMatch(new Team("Mexico"), new Team("Canada"));

--- a/src/test/java/org/aleksander/sportradar/codingtest/objects/ScoreboardTest.java
+++ b/src/test/java/org/aleksander/sportradar/codingtest/objects/ScoreboardTest.java
@@ -1,14 +1,15 @@
 package org.aleksander.sportradar.codingtest.objects;
 
 
+import org.aleksander.sportradar.codingtest.exceptions.EntryNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.security.InvalidParameterException;
 import java.util.List;
 
 import static java.lang.Thread.sleep;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ScoreboardTest {
     private final static Team TEST_HOME_TEAM = new Team("test_home_team");
@@ -35,6 +36,18 @@ public class ScoreboardTest {
         assertEquals(TEST_AWAY_TEAM, storedMatch.getAwayTeam());
         assertEquals(0, storedMatchScore.homeScore());
         assertEquals(0, storedMatchScore.awayScore());
+    }
+
+    @Test
+    void scoreboard_getting_a_match_with_an_invalid_matchId_leads_to_an_exception() {
+        // Given a new match is started
+        scoreboard.startNewMatch(TEST_HOME_TEAM, TEST_AWAY_TEAM);
+
+        // When using an invalid matchId, and trying to get a match it leads to exception
+        final EntryNotFoundException entryNotFoundException = assertThrows(EntryNotFoundException.class, () -> scoreboard.getMatch("123"));
+
+        // Then a descriptive error message is given
+        assertEquals("No match entry was found when trying to get match with matchId '123'", entryNotFoundException.getMessage());
     }
 
     @Test
@@ -84,6 +97,30 @@ public class ScoreboardTest {
         assertEquals(7, storedMatchScore.awayScore());
     }
 
+    @Test
+    void scoreboard_updating_a_match_an_invalid_matchId_leads_to_an_exception() {
+        // Given a new match is started
+        scoreboard.startNewMatch(TEST_HOME_TEAM, TEST_AWAY_TEAM);
+
+        // When using an invalid matchId, and trying to update a match it leads to exception
+        final EntryNotFoundException entryNotFoundException = assertThrows(EntryNotFoundException.class, () -> scoreboard.updateScoreOfMatch("123", new Score(1, 0)));
+
+        // Then a descriptive error message is given
+        assertEquals("No match entry was found when trying to get match with matchId '123'", entryNotFoundException.getMessage());
+    }
+
+    @Test
+    void scoreboard_updating_a_match_an_invalid_score_leads_to_an_exception() {
+        // Given a new match is started
+        final String matchId = scoreboard.startNewMatch(TEST_HOME_TEAM, TEST_AWAY_TEAM);
+
+        // When using an invalid score of 'null', and trying to update a match it leads to exception
+        final InvalidParameterException invalidParameterException = assertThrows(InvalidParameterException.class, () -> scoreboard.updateScoreOfMatch(matchId, null));
+
+        // Then a descriptive error message is given
+        assertEquals("The score provided can not be 'null'", invalidParameterException.getMessage());
+    }
+
     // Finish match
     @Test
     void scoreboard_can_finish_match() {
@@ -97,6 +134,18 @@ public class ScoreboardTest {
         // Then the match has been removed from the map of matches
         final Match storedMatch = scoreboard.getMatch(matchId);
         assertNull(storedMatch);
+    }
+
+    @Test
+    void scoreboard_finishing_a_match_with_an_invalid_matchId_leads_to_an_exception() {
+        // Given a new match is started
+        scoreboard.startNewMatch(TEST_HOME_TEAM, TEST_AWAY_TEAM);
+
+        // When using an invalid matchId, and trying to update a match it leads to exception
+        final EntryNotFoundException entryNotFoundException = assertThrows(EntryNotFoundException.class, () -> scoreboard.finishMatch("123"));
+
+        // Then a descriptive error message is given
+        assertEquals("No match entry was found when trying to get match with matchId '123'", entryNotFoundException.getMessage());
     }
 
     // Get matches in order

--- a/src/test/java/org/aleksander/sportradar/codingtest/objects/TeamTest.java
+++ b/src/test/java/org/aleksander/sportradar/codingtest/objects/TeamTest.java
@@ -1,8 +1,13 @@
 package org.aleksander.sportradar.codingtest.objects;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+import java.security.InvalidParameterException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TeamTest {
     private static final String TEAM_NAME = "test_team_name";
@@ -15,5 +20,16 @@ public class TeamTest {
         assertEquals(TEAM_NAME, team.teamName());
         // And the toString() methods returns the team name when called
         assertEquals(TEAM_NAME, team.toString());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void attempting_to_create_a_team_with_null_or_empty_as_name_throws_exception(final String invalidTeamName) {
+        // Given null or empty team name, when creating team, it throws an exception
+        final InvalidParameterException invalidParameterException = assertThrows(
+                InvalidParameterException.class, () -> new Team(invalidTeamName)
+        );
+        // and the error message is descriptive
+        assertEquals("Parameter teamName cannot be null or empty!", invalidParameterException.getMessage());
     }
 }

--- a/src/test/java/org/aleksander/sportradar/codingtest/objects/TeamTest.java
+++ b/src/test/java/org/aleksander/sportradar/codingtest/objects/TeamTest.java
@@ -1,10 +1,9 @@
 package org.aleksander.sportradar.codingtest.objects;
 
+import org.aleksander.sportradar.codingtest.exceptions.InvalidArgumentException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
-
-import java.security.InvalidParameterException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -26,10 +25,10 @@ public class TeamTest {
     @NullAndEmptySource
     void attempting_to_create_a_team_with_null_or_empty_as_name_throws_exception(final String invalidTeamName) {
         // Given null or empty team name, when creating team, it throws an exception
-        final InvalidParameterException invalidParameterException = assertThrows(
-                InvalidParameterException.class, () -> new Team(invalidTeamName)
+        final InvalidArgumentException invalidArgumentException = assertThrows(
+                InvalidArgumentException.class, () -> new Team(invalidTeamName)
         );
         // and the error message is descriptive
-        assertEquals("Parameter teamName cannot be null or empty!", invalidParameterException.getMessage());
+        assertEquals("Parameter 'teamName' cannot be null or empty!", invalidArgumentException.getMessage());
     }
 }


### PR DESCRIPTION
# Description

This PR adds some very needed error handling. Now most edge cases and invalid values should be handled in a relatively nice manner. It will throw EntryNotFoundException if a match is not found in the scoreboard list, and throw IllegalArgumentException if an invalid value is input somewhere it shouldn't be (generally 'null' or empty values for fields that are required)

# Additional context for reviewer

This PR is mostly a formality to myself :)
